### PR TITLE
Fix z-index styling in floating shapes

### DIFF
--- a/src/app/components/FloatingShapes.tsx
+++ b/src/app/components/FloatingShapes.tsx
@@ -79,7 +79,10 @@ export function FloatingShapes({
   if (!isMounted) return null;
 
   return (
-    <div className={`absolute inset-0 overflow-hidden pointer-events-none z-${z}`}>
+    <div
+      className="absolute inset-0 overflow-hidden pointer-events-none"
+      style={{ zIndex: z }}
+    >
       {shapes.map((s) => (
         <motion.div
           key={s.key}


### PR DESCRIPTION
## Summary
- fix FloatingShapes component style to avoid dynamic Tailwind class

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438ca2eb00832f84f0471218e427d4