### PR TITLE
Fix hydration warning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt-BR">
+    <html lang="pt-BR" suppressHydrationWarning>
       <head>
         {/* Script para aplicar tema antes do carregamento do JavaScript */}
         <script


### PR DESCRIPTION
## Summary
- prevent hydration mismatch by adding `suppressHydrationWarning` to `<html>` in the root layout

## Testing
- `npx next build` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438efbfb34832fab2b782174b04e8e