### PR TITLE
Fix dark mode styles

### DIFF
--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -14,9 +14,10 @@ export default function Contact() {
     handleSubmit,
     formState: { errors },
     reset,
-  } = useForm();
+  } = useForm<{ name: string; email: string; message: string }>();
 
-  const onSubmit = (data: any) => {
+  const onSubmit = (data: { name: string; email: string; message: string }) => {
+    console.log(data);
     alert("🎉 Mensagem enviada!");
     reset();
   };

--- a/src/app/components/FeaturedProjects.tsx
+++ b/src/app/components/FeaturedProjects.tsx
@@ -222,7 +222,7 @@ export default function FeaturedProjects() {
               className={`w-3 h-3 rounded-full transition-all ${
                 current === idx
                   ? "bg-blue-500 w-6"
-                  : "bg-gray-300 hover:bg-gray-400"
+                  : "bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500"
               }`}
               aria-label={`Ir para projeto ${idx + 1}`}
             />

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -6,7 +6,7 @@ import { FaGithub, FaLinkedin, FaEnvelope } from "react-icons/fa";
 
 export default function Footer() {
   return (
-    <footer className="py-12 px-4 bg-white dark:bg-gray-900 text-center border-t border-gray-100 dark:border-gray-800">
+    <footer className="py-12 px-4 bg-gradient-to-b from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 text-center border-t border-gray-100 dark:border-gray-800">
       <div className="max-w-7xl mx-auto">
         <motion.a
           href="#"

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -107,8 +107,8 @@ export default function Header() {
     <>
       <motion.nav 
         className={`fixed inset-x-0 top-0 z-50 transition-all duration-300 ${
-          scrolled 
-            ? 'backdrop-blur-xl shadow-lg border-b border-white/20 dark:border-gray-700/30' 
+          scrolled
+            ? 'backdrop-blur-xl shadow-md border-b border-gray-200 dark:border-gray-700'
             : 'backdrop-blur-md border-b border-white/10 dark:border-gray-800/20'
         }`}
         style={{

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -251,7 +251,7 @@ export default function Skills() {
       </div>
 
       <div className="max-w-7xl mx-auto grid gap-10 md:grid-cols-3 relative z-10">
-        {skills.map((s, i) => (
+        {skills.map((s) => (
           <SkillCard
             key={s.title}
             title={s.title}


### PR DESCRIPTION
## Summary
- handle form data in contact form to satisfy lint
- dark mode styles for project carousel bullets
- gradient background for footer
- lighten header shadow on light mode
- cleanup unused loop index in skills

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68439636c86c832fa1842fc81236d1c1