### PR TITLE
Fix dark mode styles for contact, skills, and footer

### DIFF
--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -7,6 +7,7 @@ import { motion } from "framer-motion";
 import { FaEnvelope, FaLinkedin, FaGithub } from "react-icons/fa";
 import { FiSend } from "react-icons/fi";
 import { FloatingShapes } from "./FloatingShapes"; // ajuste o caminho conforme sua estrutura
+import { useThemeContext } from "../contexts/ThemeContext";
 
 export default function Contact() {
   const {
@@ -22,10 +23,17 @@ export default function Contact() {
     reset();
   };
 
+  const { isDark, mounted } = useThemeContext();
+  const background = isDark
+    ? "from-gray-900 via-gray-800 to-gray-700"
+    : "from-blue-50 via-indigo-50 to-purple-50";
+
+  if (!mounted) return null;
+
   return (
     <section
       id="contact"
-      className="relative py-24 px-4 bg-gradient-to-b from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 overflow-hidden"
+      className={`relative py-24 px-4 bg-gradient-to-b ${background} overflow-hidden`}
     >
       
       <FloatingShapes palette="mixed" z={0} />

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -3,17 +3,25 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { FaGithub, FaLinkedin, FaEnvelope } from "react-icons/fa";
+import { useThemeContext } from "../contexts/ThemeContext";
 
 export default function Footer() {
+  const { isDark, mounted } = useThemeContext();
+  if (!mounted) return null;
+
+  const background = isDark
+    ? "from-gray-900 via-gray-800 to-gray-700 border-gray-800"
+    : "from-blue-50 via-indigo-50 to-purple-50 border-gray-100";
+
   return (
-    <footer className="py-12 px-4 bg-gradient-to-b from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 text-center border-t border-gray-100 dark:border-gray-800">
+    <footer className={`py-12 px-4 bg-gradient-to-b ${background} text-center border-t`}>
       <div className="max-w-7xl mx-auto">
         <motion.a
           href="#"
-          className="text-xl font-bold bg-gradient-to-r from-accent to-purple-600 bg-clip-text text-transparent inline-block mb-6 flex items-center justify-center gap-2"
+          className="text-xl font-bold bg-gradient-to-r from-accent dark:from-accent-dark to-purple-600 bg-clip-text text-transparent inline-block mb-6 flex items-center justify-center gap-2"
           whileHover={{ scale: 1.05 }}
         >
-          <span className="w-8 h-8 rounded-full bg-accent flex items-center justify-center text-white font-mono">JS</span>
+          <span className="w-8 h-8 rounded-full bg-accent dark:bg-accent-dark flex items-center justify-center text-white font-mono">JS</span>
           Jean Silva
         </motion.a>
         <div className="flex justify-center gap-6 mb-6">
@@ -21,7 +29,7 @@ export default function Footer() {
             href="https://github.com"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent transition-colors text-xl"
+            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent-dark transition-colors text-xl"
             whileHover={{ y: -3 }}
             whileTap={{ scale: 0.9 }}
             aria-label="GitHub"
@@ -32,7 +40,7 @@ export default function Footer() {
             href="https://linkedin.com"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent transition-colors text-xl"
+            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent-dark transition-colors text-xl"
             whileHover={{ y: -3 }}
             whileTap={{ scale: 0.9 }}
             aria-label="LinkedIn"
@@ -41,7 +49,7 @@ export default function Footer() {
           </motion.a>
           <motion.a
             href="mailto:jean.silva.doe@example.com"
-            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent transition-colors text-xl"
+            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent-dark transition-colors text-xl"
             whileHover={{ y: -3 }}
             whileTap={{ scale: 0.9 }}
             aria-label="Email"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,6 +35,10 @@ module.exports = {
           600: "#4f46e5",
           900: "#312e81",
         },
+        accent: {
+          DEFAULT: "var(--color-accent)",
+          dark: "var(--color-accent-dark)",
+        },
         slate: {
           50: "#f8fafc",
         },


### PR DESCRIPTION
## Summary
- improve dark/light mode handling in Contact and Footer
- expose `accent` color in tailwind config

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68461a7335b0832f8838e048f2978866