### PR TITLE
Fix dark mode for Skills and clean comments

### DIFF
--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -6,7 +6,8 @@ import { useForm } from "react-hook-form";
 import { motion } from "framer-motion";
 import { FaEnvelope, FaLinkedin, FaGithub } from "react-icons/fa";
 import { FiSend } from "react-icons/fi";
-import { FloatingShapes } from "./FloatingShapes"; // ajuste o caminho conforme sua estrutura
+import { FloatingShapes } from "./FloatingShapes";
+import { useThemeContext } from "../contexts/ThemeContext";
 
 export default function Contact() {
   const {
@@ -22,10 +23,17 @@ export default function Contact() {
     reset();
   };
 
+  const { isDark, mounted } = useThemeContext();
+  const background = isDark
+    ? "from-gray-900 via-gray-800 to-gray-700"
+    : "from-blue-50 via-indigo-50 to-purple-50";
+
+  if (!mounted) return null;
+
   return (
     <section
       id="contact"
-      className="relative py-24 px-4 bg-gradient-to-b from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 overflow-hidden"
+      className={`relative py-24 px-4 bg-gradient-to-b ${background} overflow-hidden`}
     >
       
       <FloatingShapes palette="mixed" z={0} />

--- a/src/app/components/FeaturedProjects.tsx
+++ b/src/app/components/FeaturedProjects.tsx
@@ -10,7 +10,8 @@ import {
   FiChevronRight,
   FiExternalLink,
 } from "react-icons/fi";
-import { FloatingShapes } from "./FloatingShapes"; // ajuste o caminho conforme sua estrutura
+import { FloatingShapes } from "./FloatingShapes";
+import { useThemeContext } from "../contexts/ThemeContext";
 
 const projects = [
   {
@@ -56,6 +57,11 @@ const projects = [
 
 export default function FeaturedProjects() {
   const [current, setCurrent] = useState(0);
+  const { isDark, mounted } = useThemeContext();
+
+  const background = isDark
+    ? "from-gray-900 via-gray-800 to-gray-700"
+    : "from-blue-50 via-indigo-50 to-purple-50";
 
   const prev = () =>
     setCurrent((i) => (i - 1 + projects.length) % projects.length);
@@ -73,10 +79,12 @@ export default function FeaturedProjects() {
     });
   }, [current]);
 
+  if (!mounted) return null;
+
   return (
     <section
       id="projects"
-      className="relative py-24 px-4 bg-gradient-to-b from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 overflow-hidden"
+      className={`relative py-24 px-4 bg-gradient-to-b ${background} overflow-hidden`}
     >
       
       <FloatingShapes palette="mixed" z={0} />
@@ -84,7 +92,7 @@ export default function FeaturedProjects() {
       
       <div className="max-w-7xl mx-auto text-center mb-16 relative z-10">
         <motion.h2
-          className="text-3xl sm:text-4xl font-bold mb-3 bg-gradient-to-r from-blue-500 to-cyan-500 bg-clip-text text-transparent tracking-wide"
+          className="text-3xl sm:text-4xl font-bold mb-3 bg-gradient-to-r from-accent dark:from-accent-dark to-purple-600 bg-clip-text text-transparent tracking-wide"
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.7 }}

--- a/src/app/components/FloatingShapes.tsx
+++ b/src/app/components/FloatingShapes.tsx
@@ -10,14 +10,14 @@ type Palette =
   | "purple"
   | "teal"
   | "pink"
-  | "mixed"; // “mixed” → usa todas
+  | "mixed";
 
 interface Props {
-  amount?: number;     // quantos blobs
-  size?: [number, number]; // [min, max] em px
-  blur?: number;       // default 24
+  amount?: number;
+  size?: [number, number];
+  blur?: number;
   palette?: Palette;
-  z?: number;          // z-index, default 0
+  z?: number;
 }
 
 const lightPalettes: Record<Palette, string[]> = {

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -3,17 +3,25 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { FaGithub, FaLinkedin, FaEnvelope } from "react-icons/fa";
+import { useThemeContext } from "../contexts/ThemeContext";
 
 export default function Footer() {
+  const { isDark, mounted } = useThemeContext();
+  if (!mounted) return null;
+
+  const background = isDark
+    ? "from-gray-900 via-gray-800 to-gray-700 border-gray-800"
+    : "from-blue-50 via-indigo-50 to-purple-50 border-gray-100";
+
   return (
-    <footer className="py-12 px-4 bg-gradient-to-b from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 text-center border-t border-gray-100 dark:border-gray-800">
+    <footer className={`py-12 px-4 bg-gradient-to-b ${background} text-center border-t`}>
       <div className="max-w-7xl mx-auto">
         <motion.a
           href="#"
-          className="text-xl font-bold bg-gradient-to-r from-accent to-purple-600 bg-clip-text text-transparent inline-block mb-6 flex items-center justify-center gap-2"
+          className="text-xl font-bold bg-gradient-to-r from-accent dark:from-accent-dark to-purple-600 bg-clip-text text-transparent inline-block mb-6 flex items-center justify-center gap-2"
           whileHover={{ scale: 1.05 }}
         >
-          <span className="w-8 h-8 rounded-full bg-accent flex items-center justify-center text-white font-mono">JS</span>
+          <span className="w-8 h-8 rounded-full bg-accent dark:bg-accent-dark flex items-center justify-center text-white font-mono">JS</span>
           Jean Silva
         </motion.a>
         <div className="flex justify-center gap-6 mb-6">
@@ -21,7 +29,7 @@ export default function Footer() {
             href="https://github.com"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent transition-colors text-xl"
+            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent-dark transition-colors text-xl"
             whileHover={{ y: -3 }}
             whileTap={{ scale: 0.9 }}
             aria-label="GitHub"
@@ -32,7 +40,7 @@ export default function Footer() {
             href="https://linkedin.com"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent transition-colors text-xl"
+            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent-dark transition-colors text-xl"
             whileHover={{ y: -3 }}
             whileTap={{ scale: 0.9 }}
             aria-label="LinkedIn"
@@ -41,7 +49,7 @@ export default function Footer() {
           </motion.a>
           <motion.a
             href="mailto:jean.silva.doe@example.com"
-            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent transition-colors text-xl"
+            className="text-gray-500 dark:text-gray-400 hover:text-accent dark:hover:text-accent-dark transition-colors text-xl"
             whileHover={{ y: -3 }}
             whileTap={{ scale: 0.9 }}
             aria-label="Email"

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -7,7 +7,7 @@ import VanillaTilt from "vanilla-tilt";
 import { FaCode, FaServer, FaCloud } from "react-icons/fa";
 import { useThemeContext } from "../contexts/ThemeContext";
 
-const BackgroundGrid = () => (
+const BackgroundGrid = ({ dark }: { dark: boolean }) => (
   <div className="absolute inset-0 opacity-10">
     <svg className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
       <defs>
@@ -17,7 +17,7 @@ const BackgroundGrid = () => (
             fill="none"
             stroke="currentColor"
             strokeWidth="1"
-            className="text-indigo-400"
+            className={dark ? "text-indigo-800" : "text-indigo-400"}
           />
         </pattern>
       </defs>
@@ -226,12 +226,12 @@ export default function Skills() {
       className={`relative py-24 px-4 overflow-hidden transition-all duration-500 ${backgroundClasses}`}
     >
       
-      <BackgroundGrid />
+      <BackgroundGrid dark={isDark} />
       <FloatingElements />
 
       <div className="max-w-7xl mx-auto text-center mb-16 relative z-10">
         <motion.h2
-          className="text-4xl sm:text-5xl font-bold mb-4 bg-gradient-to-r from-blue-500 to-cyan-500 bg-clip-text text-transparent tracking-wide"
+          className="text-4xl sm:text-5xl font-bold mb-4 bg-gradient-to-r from-accent dark:from-accent-dark to-purple-600 bg-clip-text text-transparent tracking-wide"
           initial={{ opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.7 }}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,3 @@
-/* src/app/globals.css */
 @import "tailwindcss";
 
 :root {
@@ -13,7 +12,6 @@
   --color-accent-dark: #3b82f6;
 }
 
-/* Transições globais suaves */
 *,
 *::before,
 *::after {
@@ -36,25 +34,21 @@ body {
   color: var(--color-light);
 }
 
-/* Garantir transições suaves para seções com gradientes */
 section {
   transition: background 400ms ease, color 400ms ease;
 }
 
-/* Hero background transitions */
 .bg-gradient-to-br {
   transition: all 400ms ease;
 }
 
-/* Garantir que inputs e textareas herdem a cor correta */
 input, textarea, select {
   color: inherit;
   background-color: inherit;
   transition: all 300ms ease;
 }
 
-/* Transições para elementos de tema específicos */
-.bg-white, 
+.bg-white,
 .dark\:bg-gray-900,
 .text-gray-900, 
 .dark\:text-white,
@@ -64,14 +58,12 @@ input, textarea, select {
   transition: all 400ms ease;
 }
 
-/* Suavizar bordas e sombras */
 .border,
 .shadow-lg,
 .shadow-xl {
   transition: all 300ms ease;
 }
 
-/* Garantir que as cores de texto mudem suavemente */
 .text-gray-600,
 .text-gray-700,
 .text-gray-800,
@@ -81,7 +73,6 @@ input, textarea, select {
   transition: color 400ms ease;
 }
 
-/* Garantir que gradientes de fundo respondam ao tema */
 .from-slate-50,
 .via-blue-50,
 .to-indigo-100,
@@ -91,12 +82,10 @@ input, textarea, select {
   transition: all 400ms ease;
 }
 
-/* Evitar flash inicial */
 html.loading * {
   transition: none !important;
 }
 
-/* Suavizar animações do VanillaTilt */
 .tilt-card {
   transform-style: preserve-3d;
 }

--- a/src/app/hooks/useThemeSwitcher.tsx
+++ b/src/app/hooks/useThemeSwitcher.tsx
@@ -1,14 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-
-/**
- * Hook único para todo o app:  
- *  - Lê `localStorage.getItem("theme")` no primeiro mount.  
- *  - Se estiver “dark”, aplica a classe `dark` em <html> e retorna isDark = true.  
- *  - Caso contrário, checa `prefers-color-scheme` (e aplica `dark` se for “dark”).  
- *  - Sempre que `isDark` muda, atualiza (add/remove) a classe `dark` em <html> e grava em localStorage.
- */
 export function useThemeSwitcher() {
   const [isDark, setIsDark] = useState(false);
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,3 @@
-// tailwind.config.ts
 module.exports = {
   content: ["./src/app/**/*.{js,ts,jsx,tsx}", "./src/components/**/*.{js,ts,jsx,tsx}"],
   darkMode: "class",
@@ -34,6 +33,10 @@ module.exports = {
           500: "#6366f1",
           600: "#4f46e5",
           900: "#312e81",
+        },
+        accent: {
+          DEFAULT: "var(--color-accent)",
+          dark: "var(--color-accent-dark)",
         },
         slate: {
           50: "#f8fafc",


### PR DESCRIPTION
## Summary
- tweak background grid color based on theme
- use accent gradient in Skills header
- remove stale comments across components and config
- adapt FeaturedProjects background to theme

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68461a7335b0832f8838e048f2978866